### PR TITLE
Add an initial name option when creating a device and components

### DIFF
--- a/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -29,13 +29,35 @@
 				<Label>MQTT Broker:</Label>
 				<List class="self" filter="" method="get_broker_devices" dynamicReload="true"/>
 			</Field>
+			<Field id="broker-description" type="label" alignWithControl="true" fontColor="darkgray">
+				<Label>The broker that this device communicates with
+				</Label>
+			</Field>
 
 			<Field id="address" type="textfield">
 				<Label>Base MQTT Topic:</Label>
 			</Field>
+			<Field id="address-description" type="label" alignWithControl="true" fontColor="darkgray">
+				<Label>The base address of the device
+				</Label>
+			</Field>
 
 			<Field id="message-type" type="textfield">
 				<Label>Message Type:</Label>
+			</Field>
+			<Field id="message-type-description" type="label" alignWithControl="true" fontColor="darkgray">
+				<Label>The message type from an MQTTConnector trigger that will be delivering messages for this device
+				</Label>
+			</Field>
+
+			<Field id="is-initial-setup" type="checkbox" defaultValue="true" hidden="true" />
+
+			<Field id="initial-name" type="textfield" visibleBindingId="is-initial-setup" visibleBindingValue="true">
+				<Label>Initial Name:</Label>
+			</Field>
+			<Field id="initial-name-description" type="label" visibleBindingId="is-initial-setup" visibleBindingValue="true" alignWithControl="true" fontColor="darkgray">
+				<Label>The base name for the device (ex: Living Room Light) that can be used to create friendly default component names
+				</Label>
 			</Field>
 
 			<Field id="model-specific-sep" type="separator" visibleBindingId="shelly-model" visibleBindingValue="shelly-plus-2-pm,shelly-pro-2-pm"/>

--- a/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -315,6 +315,7 @@ class Plugin(indigo.PluginBase):
             values_dict['broker-id'] = main_device.pluginProps['broker-id']
             values_dict['address'] = main_device.pluginProps['address']
             values_dict['message-type'] = main_device.pluginProps['message-type']
+            values_dict['is-initial-setup'] = main_device.pluginProps['is-initial-setup']
 
         return values_dict, errors_dict
 
@@ -407,11 +408,17 @@ class Plugin(indigo.PluginBase):
         device_props = {
             'broker-id': values_dict["broker-id"],
             'address': values_dict["address"],
-            'message-type': values_dict["message-type"]
+            'message-type': values_dict["message-type"],
+            'is-initial-setup': False
         }
         if model_class.display_name not in group_models:
             # The main device is not in the group, so create one
-            main_device = indigo.device.create(indigo.kProtocol.Plugin, deviceTypeId=shelly_model, props=device_props)
+            main_device = indigo.device.create(
+                indigo.kProtocol.Plugin,
+                name=values_dict["initial-name"] or None,
+                deviceTypeId=shelly_model,
+                props=device_props
+            )
             main_device.model = model_class.display_name
             main_device.replaceOnServer()
         else:

--- a/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/shelly/devices/Shelly.py
+++ b/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/shelly/devices/Shelly.py
@@ -419,9 +419,12 @@ class Shelly(object):
             # The component name we are trying to register is new, so we did
             # not find a device with that name already in the group. Create it
             # and add it to the group.
-            device = indigo.device.create(indigo.kProtocol.Plugin,
-                                          deviceTypeId=component_class.device_type_id,
-                                          groupWithDevice=self.device.id)
+            ui_name = "{} {}".format(self.device.name, name)
+            device = indigo.device.create(
+                indigo.kProtocol.Plugin,
+                name=ui_name,
+                deviceTypeId=component_class.device_type_id,
+                groupWithDevice=self.device.id)
             device.model = name
             device.replaceOnServer()
             self.component_devices[name] = device


### PR DESCRIPTION
Closes #13

An initial name field is present in the device factory UI only on trial creation. This name is used as a prefix to all component types.

For example, a value of "My Device" will create the main device named "My Device", and a switch component of "My Device Switch".

No name will let indigo name the device, and components will append their type to the indigo-created name.