### PR TITLE
Append (mini) to the 1 and 1PM device names

### DIFF
--- a/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/ShellyNGMQTT.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -7,8 +7,8 @@
 			￼<Field type="menu" id="shelly-model" defaultValue="shelly-plus-1">
 				<Label>Shelly Model:</Label>
 				<List>
-					<Option value="shelly-plus-1">Shelly Plus 1</Option>
-					<Option value="shelly-plus-1-pm">Shelly Plus 1 PM</Option>
+					<Option value="shelly-plus-1">Shelly Plus 1 (mini)</Option>
+					<Option value="shelly-plus-1-pm">Shelly Plus 1 PM (mini)</Option>
 					<Option value="shelly-plus-2-pm">Shelly Plus 2 PM</Option>
 					<Option value="shelly-plus-walldimmer">%%disabled:Shelly Plus WallDimmer (Coming Soon!)%%</Option>
 					<Option value="-1">%%separator%%</Option>


### PR DESCRIPTION
The Plus 1 mini and Plus 1PM mini appear API compatible with the Plus 1 and Plus 1PM respectively. This change just add the `(mini)` signifier to the model selection when creating a new device.